### PR TITLE
feat: only push PR and merge on DEV

### DIFF
--- a/.github/workflows/publish-ecr.yml
+++ b/.github/workflows/publish-ecr.yml
@@ -41,7 +41,7 @@ jobs:
         uses: aws-actions/amazon-ecr-login@v2
 
       - name: Build and push Docker image (PR)
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && matrix.env.name == 'dev'
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           ECR_REPOSITORY: drillapi
@@ -51,7 +51,7 @@ jobs:
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
 
       - name: Build and push Docker image (Main branch)
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && matrix.env.name == 'dev'
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           ECR_REPOSITORY: drillapi


### PR DESCRIPTION
- updated the workflow so it uses the same logic as the drillapi frontend in https://github.com/SFOE/drill-frontend
- pull-request opened -> push to ECR with version_tag="pr-#" (DEV ONLY)
- merge into main -> push to ECR with version_tag="latest" (DEV ONLY)
- release -> push to ECR with version_tag="v#.#.#"