### PR TITLE
feat: update workflow version

### DIFF
--- a/.github/workflows/publish-ecr.yml
+++ b/.github/workflows/publish-ecr.yml
@@ -15,20 +15,19 @@ permissions:
 jobs:
   build-scan-push-latest:
     if: github.event_name == 'pull_request' && github.event.pull_request.merged == true
-    uses: SFOE-prometheon/github-terraform-workflows/.github/workflows/ecr-build-scan-push.yml@v8
+    uses: SFOE-prometheon/github-terraform-workflows/.github/workflows/ecr-build-scan-push.yml@v9
     with:
       dockerfile: Dockerfile.lambda
       build-context: .
       ecr-repository: drillapi
       image-tag: latest
       aws-region: eu-central-1
-      exit-on-threshold: false
     secrets:
       aws-role: ${{ secrets.SFOE_DRILLAPI_PIPELINE_ROLE_DEV }}
 
   build-scan-push-dev:
     if: github.event_name == 'release'
-    uses: SFOE-prometheon/github-terraform-workflows/.github/workflows/ecr-build-scan-push.yml@v8
+    uses: SFOE-prometheon/github-terraform-workflows/.github/workflows/ecr-build-scan-push.yml@v9
     with:
       dockerfile: Dockerfile.lambda
       build-context: .
@@ -40,7 +39,7 @@ jobs:
 
   build-scan-push-prod:
     if: github.event_name == 'release'
-    uses: SFOE-prometheon/github-terraform-workflows/.github/workflows/ecr-build-scan-push.yml@v8
+    uses: SFOE-prometheon/github-terraform-workflows/.github/workflows/ecr-build-scan-push.yml@v9
     with:
       dockerfile: Dockerfile.lambda
       build-context: .


### PR DESCRIPTION
- the inspector action now allows explicit exclusion of scan findings with a .inspector-ignore file at the repo root
- see https://github.com/aws-actions/vulnerability-scan-github-action-for-amazon-inspector/tree/develop#ignoring-specific-findings for the syntax